### PR TITLE
Use new-style class definition to compliment the use of super()

### DIFF
--- a/session2/Object Oriented Intro.ipynb
+++ b/session2/Object Oriented Intro.ipynb
@@ -322,7 +322,7 @@
    },
    "outputs": [],
    "source": [
-    "class Point:\n",
+    "class Point(object):\n",
     "    def __init__(self, x, y):\n",
     "        # this is the method that gets called when you create a new Point\n",
     "        self.x = x\n",
@@ -425,7 +425,7 @@
    },
    "outputs": [],
    "source": [
-    "class Astronomer:\n",
+    "class Astronomer(object):\n",
     "    def __init__(self):\n",
     "        self._science_done = []\n",
     "        \n",


### PR DESCRIPTION
I'm 99% sure Python 3 defaults to using new-style classes regardless if you use the `class thing(object)` convention, but some people might be running these examples under Python 2, and it defaults to old-style classes when `(object)` is missing.

Thoughts?
