### PR TITLE
Use pkg-config for portable cython building

### DIFF
--- a/session8/Cython.ipynb
+++ b/session8/Cython.ipynb
@@ -204,14 +204,16 @@
    "source": [
     "# Now lets do a \"hello world\" example\n",
     "\n",
-    "* First make sure you have cython installed (``conda install cython`` should work).\n",
+    "* First make sure you have cython and pkg-config installed (``conda install cython pkg-config`` should work).\n",
     "* Look at the file ``hello_world.pyx`` in the spacetelescope/pylunch repo. \n",
     "* Open up a terminal and go to the repo and do ``cython hello_world.pyx``.  It should create a ``hello_world.c`` file.\n",
     "* Now compile that file.  This can be tricky to know the right flags.  For me, this worked:\n",
-    "```\n",
-    "clang -bundle -undefined dynamic_lookup -L/Users/erik/miniconda3/envs/anaconda/lib -arch x86_64 build/temp.macosx-10.6-x86_64-3.5/astropy/_compiler.o -L/Users/erik/miniconda3/envs/anaconda/lib hello_world.c hello_world.so\n",
-    "```\n",
-    "try that but with \"anaconda\" replaced by your current conda environment.  If you have trouble, check out http://cython.readthedocs.io/en/latest/src/reference/compilation.html .  If you still have trouble, try the method in http://cython.readthedocs.io/en/latest/src/tutorial/cython_tutorial.html, or just wait for a bit."
+    "   ```\n",
+    "   clang -bundle $(pkg-config --libs --cflags python) ./hello_world.c -o hello_world.so\n",
+    "   ```\n",
+    "\n",
+    "\n",
+    "If you have trouble, check out http://cython.readthedocs.io/en/latest/src/reference/compilation.html .  If you still have trouble, try the method in http://cython.readthedocs.io/en/latest/src/tutorial/cython_tutorial.html, or just wait for a bit."
    ]
   },
   {

--- a/session8/hello_world.pyx
+++ b/session8/hello_world.pyx
@@ -3,4 +3,4 @@ from libc.stdio cimport printf
 def do_hello():
     print("hello world from python")
 
-    printf("hello world from c")
+    printf("hello world from c\n")


### PR DESCRIPTION
Still Mac-specific clang flags, but a _little_ more likely to work out of the box.
